### PR TITLE
Matching version of cross shadow

### DIFF
--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -686,54 +686,53 @@ void func_80169C10(Entity* entity) {
 }
 
 // made by blueprint #5, see step 0 of EntityCrossBoomerang
-void EntityCrossShadow(Entity* entity) {
-    Point16* temp;
-    s16* ptr;
+void EntityCrossShadow(Entity* self) {
+    s16* temp;
 
-    switch (entity->step) {
+    switch (self->step) {
     case 0:
-        entity->flags = FLAG_UNK_04000000 | FLAG_UNK_08000000;
+        self->flags = FLAG_UNK_04000000 | FLAG_UNK_08000000;
         // the parent pointer is set in RicEntityEntFactory.
         // the value of unk84 is set in EntityCrossBoomerang
-        entity->ext.crossBoomerang.unk84 =
-            entity->ext.factory.parent->ext.crossBoomerang.unk84;
-        entity->animSet = ANIMSET_OVL(17);
-        entity->animCurFrame = D_80155E68[entity->params];
-        entity->unk5A = 0x66;
-        entity->palette = 0x81B0;
-        entity->drawMode = DRAW_TPAGE;
-        entity->facingLeft = PLAYER.facingLeft;
-        entity->zPriority = PLAYER.zPriority;
-        entity->drawFlags = FLAG_DRAW_ROTZ;
-        entity->rotZ = 0xC00;
-        entity->step++;
+        self->ext.crossBoomerang.unk84 =
+            self->ext.factory.parent->ext.crossBoomerang.unk84;
+        self->animSet = ANIMSET_OVL(17);
+        self->animCurFrame = D_80155E68[self->params];
+        self->unk5A = 0x66;
+        self->palette = 0x81B0;
+        self->drawMode = DRAW_TPAGE;
+        self->facingLeft = PLAYER.facingLeft;
+        self->zPriority = PLAYER.zPriority;
+        self->drawFlags = FLAG_DRAW_ROTZ;
+        self->rotZ = 0xC00;
+        self->step++;
         break;
 
     case 1:
-        entity->rotZ -= 0x80;
-        if (entity->ext.factory.parent->step == 7) {
-            entity->step++;
-            entity->ext.generic.unk7C.s = (entity->params + 1) * 4;
+        self->rotZ -= 0x80;
+        if (self->ext.factory.parent->step == 7) {
+            self->step++;
+            self->ext.timer.t = (self->params + 1) * 4;
         }
         break;
 
     case 2:
-        entity->rotZ -= 0x80;
-        entity->ext.generic.unk7C.s--;
-        if (entity->ext.generic.unk7C.s == 0) {
-            DestroyEntity(entity);
+        self->rotZ -= 0x80;
+        if (--self->ext.timer.t == 0) {
+            DestroyEntity(self);
             return;
         }
         break;
     }
 
     // get the x and y position from the parent (must align)
-    temp = entity->ext.crossBoomerang.unk84;
-    ptr = temp + entity->ext.crossBoomerang.unk80 * 4;
-    entity->posX.i.hi = temp->x - g_Tilemap.scrollX.i.hi;
-    entity->posY.i.hi = temp->y - g_Tilemap.scrollY.i.hi;
-    entity->ext.generic.unk80.modeS16.unk0 =
-        (entity->ext.generic.unk80.modeS16.unk0 + 1) & 0x3F;
+    temp = &self->ext.crossBoomerang.unk84[0];
+    temp += self->ext.crossBoomerang.unk80 * 2;
+    self->posX.i.hi = *temp - g_Tilemap.scrollX.i.hi;
+    temp++;
+    self->posY.i.hi = *temp - g_Tilemap.scrollY.i.hi;
+    self->ext.crossBoomerang.unk80++;
+    self->ext.crossBoomerang.unk80 &= 0x3F;
 }
 
 // Entity ID #32. Comes from blueprint 34.

--- a/src/ric/2C4C4.c
+++ b/src/ric/2C4C4.c
@@ -712,13 +712,13 @@ void EntityCrossShadow(Entity* self) {
         self->rotZ -= 0x80;
         if (self->ext.factory.parent->step == 7) {
             self->step++;
-            self->ext.timer.t = (self->params + 1) * 4;
+            self->ext.crossBoomerang.timer = (self->params + 1) * 4;
         }
         break;
 
     case 2:
         self->rotZ -= 0x80;
-        if (--self->ext.timer.t == 0) {
+        if (--self->ext.crossBoomerang.timer == 0) {
             DestroyEntity(self);
             return;
         }


### PR DESCRIPTION
I also took the liberty of eliminating the uses of ext.generic, and changing the function to be a 'self' rather than 'entity'.

Should allow https://github.com/Xeeynamo/sotn-decomp/pull/1498 to be completed smoothly.